### PR TITLE
Single-click theme toggle + GameFinalized prize pool from history

### DIFF
--- a/src/lib/common/game.ts
+++ b/src/lib/common/game.ts
@@ -187,6 +187,7 @@ export interface GameFinalized {
     resolverPK_Hex: string | null;
     resolverScript_Hex: string;
     resolverCommission: number;
+    devCommission: number;
 }
 
 /**

--- a/src/lib/dev/dev-competitions.ts
+++ b/src/lib/dev/dev-competitions.ts
@@ -678,6 +678,7 @@ function buildScenarioState(
         resolverPK_Hex: DEFAULT_PLAYER_PK_HEX,
         resolverScript_Hex: `0008cd${DEFAULT_PLAYER_PK_HEX}`,
         resolverCommission,
+        devCommission,
     });
 
     switch (definition.key) {

--- a/src/lib/ergo/fetch.ts
+++ b/src/lib/ergo/fetch.ts
@@ -829,6 +829,13 @@ export async function fetchFinalizedGames(): Promise<Map<string, GameFinalized>>
         const judgeFinalizationBlock = lastResolutionBox?.resolutionDeadline || 0;
         const winnerFinalizationGracePeriod = getGameConstants().END_GAME_AUTH_GRACE_PERIOD;
 
+        // Prize pool is derived from the HISTORICAL record, not the live box: once a
+        // game is finalized the NFT sits in a non-contract box (winner/resolver wallet)
+        // that no longer holds the participation tokens, so the live box reports 0.
+        // The last resolution/end-game contract box (the one spent by the finalize tx)
+        // still carries the participation-token balance, i.e. the final prize pool.
+        const finalPrizeValue = lastResolutionBox?.value ?? lastBox.value;
+
         const finalized: GameFinalized = {
             boxId: lastResolutionBox?.boxId || currentBox.boxId, // Use resolution box ID if available
             box: lastResolutionBox?.box || currentBox, // Use resolution box if available
@@ -837,7 +844,7 @@ export async function fetchFinalizedGames(): Promise<Map<string, GameFinalized>>
             deadlineBlock: lastBox.deadlineBlock,
             gameId,
             content: lastBox.content,
-            value: lastBox.value,
+            value: finalPrizeValue,
             participationTokenId: lastBox.participationTokenId,
             participationFeeAmount: BigInt(lastBox.participationFeeAmount || 0),
             reputationOpinions: await fetchReputationOpinionsForTarget("game", gameId),
@@ -855,6 +862,7 @@ export async function fetchFinalizedGames(): Promise<Map<string, GameFinalized>>
             resolverPK_Hex: lastResolutionBox?.resolverPK_Hex || null,
             resolverScript_Hex: lastResolutionBox?.resolverScript_Hex || "",
             resolverCommission: lastResolutionBox?.resolverCommission || 0,
+            devCommission: lastResolutionBox?.devCommission || 0,
             createdAt: lastResolutionBox?.createdAt || (('createdAt' in lastBox) ? (lastBox as any).createdAt : 0)
         };
 
@@ -1446,8 +1454,10 @@ export async function fetchGame(id: string): Promise<AnyGame | null> {
         console.error(`fetchGame: error parsing current box for ${id}:`, e);
     }
 
-    // 4) If we reached here we need to collect historical contract boxes for this token id
-    const templateHashes = [activeTemplate, resolutionTemplate, cancellationTemplate];
+    // 4) If we reached here we need to collect historical contract boxes for this token id.
+    //    endGameTemplate must be included: the end-game box is the contract box spent by
+    //    the finalize tx and the one that still carries the participation-token prize pool.
+    const templateHashes = [activeTemplate, resolutionTemplate, endGameTemplate, cancellationTemplate];
     const histBoxes: AnyGame[] = [];
 
     const limit = 100;
@@ -1513,6 +1523,14 @@ export async function fetchGame(id: string): Promise<AnyGame | null> {
         const judgeFinalizationBlock = lastResolutionBox?.resolutionDeadline || 0;
         const winnerFinalizationGracePeriod = 64800; // 90 days (as in fetchFinalizedGames) - TODO: take from contract constants if available
 
+        // Prize pool is derived from the HISTORICAL record, not the live box. `currentBox`
+        // (the box now holding the NFT) is a winner/resolver wallet box that no longer
+        // carries the participation tokens, so `currentBox.value` / `lastBox.box.value`
+        // would report a near-zero prize pool. The last resolution/end-game contract box
+        // (spent by the finalize tx) still carries the participation-token balance, which
+        // is the final prize pool consumed by getPrizePool().
+        const finalPrizeValue = lastResolutionBox?.value ?? lastBox.value;
+
         // build finalized object
         try {
             const finalized: GameFinalized = {
@@ -1523,7 +1541,7 @@ export async function fetchGame(id: string): Promise<AnyGame | null> {
                 deadlineBlock: lastBox.deadlineBlock,
                 gameId: id,
                 content: lastBox.content,
-                value: BigInt(lastBox.box.value),
+                value: finalPrizeValue,
                 participationFeeAmount: BigInt(lastBox.participationFeeAmount || 0),
                 participationTokenId: lastBox.participationTokenId,
                 reputationOpinions: await fetchReputationOpinionsForTarget("game", id),
@@ -1542,6 +1560,7 @@ export async function fetchGame(id: string): Promise<AnyGame | null> {
                 resolverPK_Hex: lastResolutionBox?.resolverPK_Hex || null,
                 resolverScript_Hex: lastResolutionBox?.resolverScript_Hex || "",
                 resolverCommission: lastResolutionBox?.resolverCommission || 0,
+                devCommission: lastResolutionBox?.devCommission || 0,
                 createdAt: lastResolutionBox?.createdAt || (('createdAt' in lastBox) ? (lastBox as any).createdAt : 0)
             };
 
@@ -1604,6 +1623,7 @@ export async function fetchGame(id: string): Promise<AnyGame | null> {
                 resolverPK_Hex: null,
                 resolverScript_Hex: "",
                 resolverCommission: 0,
+                devCommission: 0,
                 createdAt: await tokenCreationHeight(id) || 0
             };
             minimal.reputation = calculate_reputation(minimal);

--- a/src/routes/Theme.svelte
+++ b/src/routes/Theme.svelte
@@ -2,26 +2,42 @@
     import Sun from "lucide-svelte/icons/sun";
     import Moon from "lucide-svelte/icons/moon";
 
-    import { resetMode, setMode } from "mode-watcher";
-    import * as DropdownMenu from "$lib/components/ui/dropdown-menu/index.js";
+    import { toggleMode } from "mode-watcher";
     import { Button } from "$lib/components/ui/button/index.js";
+
+    // Single-click circular toggle (light <-> dark), following
+    // StabilityNexus/BenefactionPlatform-Ergo PR #172. `toggleMode` flips the
+    // active mode in one step; the wrapper spins 180deg per click so the
+    // sun/moon swap reads as a rotation rather than a hard cut. The system
+    // default is still respected until the user makes a first explicit choice.
+    let rotationDeg = 0;
+
+    function handleToggleClick() {
+        toggleMode();
+        rotationDeg += 180;
+    }
 </script>
 
-<DropdownMenu.Root>
-<DropdownMenu.Trigger asChild let:builder>
-    <Button builders={[builder]} variant="outline" size="icon">
-    <Sun
-    class="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0"
-    />
-    <Moon
-    class="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100"
-    />
-    <span class="sr-only">Toggle theme</span>
+<div class="theme-toggle-motion" style={`transform: rotate(${rotationDeg}deg);`}>
+    <Button
+        variant="outline"
+        size="icon"
+        class="rounded-full"
+        on:click={handleToggleClick}
+    >
+        <Sun
+            class="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0"
+        />
+        <Moon
+            class="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100"
+        />
+        <span class="sr-only">Toggle theme</span>
     </Button>
-</DropdownMenu.Trigger>
-<DropdownMenu.Content align="end">
-    <DropdownMenu.Item on:click={() => setMode("light")}>Light</DropdownMenu.Item>
-    <DropdownMenu.Item on:click={() => setMode("dark")}>Dark</DropdownMenu.Item>
-    <DropdownMenu.Item on:click={() => resetMode()}>System</DropdownMenu.Item>
-</DropdownMenu.Content>
-</DropdownMenu.Root>
+</div>
+
+<style>
+    .theme-toggle-motion {
+        display: inline-block;
+        transition: transform 700ms ease;
+    }
+</style>


### PR DESCRIPTION
## Summary

Two independent changes (one commit each).

### 1. Single-click circular theme toggle — `src/routes/Theme.svelte`
Replaces the 3-option Light/Dark/System dropdown with a one-click circular toggle, following [StabilityNexus/BenefactionPlatform-Ergo PR #172](https://github.com/StabilityNexus/BenefactionPlatform-Ergo/pull/172).

- Uses mode-watcher's `toggleMode()` to flip light↔dark in a single click (instead of `setMode`/`resetMode`).
- Button is `rounded-full`; the wrapper rotates `180deg` per click (700ms transition) so the sun/moon icon swap reads as a spin.
- System default is still respected until the user makes a first explicit choice.
- Accessibility preserved: real `<button>` (via the existing `Button` component) + `sr-only` "Toggle theme" label.

Adapted from the already-merged equivalent in the sibling `skills` app, retargeted to this app's `mode-watcher` setup (identical Button/icon structure here, so the adaptation is a near-1:1 port).

**Validation of PR #172 — verdict: sound.** The approach is correct and minimal: `toggleMode()` is the canonical mode-watcher mechanism for a binary toggle and correctly preserves system-default behavior until first explicit interaction; accessibility is preserved. One stylistic note: PR #172 uses a transient `turning` boolean reset by a `setTimeout(700ms)` to drive the rotation, which can desync if clicked faster than the timeout. This PR instead uses a monotonically increasing `rotationDeg += 180` accumulator (as in the merged `skills` app version) — no timers, no desync, and the CSS transition handles the animation. Functionally equivalent UX, slightly more robust. No correctness issues found in #172.

### 2. GameFinalized prize pool & commissions from history — `src/lib/ergo/fetch.ts`
Once a game is finalized, the game NFT moves to a **non-contract** box (winner/resolver wallet) that no longer holds the participation tokens. The finalized prize pool was being read from that live box, so `getPrizePool()` saw a 0 (or near-0) token balance — and after subtracting the resolver stake it clamped to **0**.

Fix: derive the final prize pool from the **historical record** — specifically the last resolution / end-game contract box (the box spent by the finalize tx), which still carries the participation-token balance. This is exactly the box whose `box_value(SELF)` the `end_game.es` contract uses to compute the prize pool, so it is the correct source of truth.

- **`fetchGame`** (single-game path, e.g. deep-link to a finalized game): two bugs fixed.
  1. `endGameTemplate` was missing from the historical template search, so the end-game box (which holds the prize) was never fetched. Added it.
  2. `value` was set to `BigInt(lastBox.box.value)` — the box's **nanoERG**, not the participation-token amount. Now derives from the last resolution/end-game box's participation-token balance (`lastResolutionBox?.value ?? lastBox.value`).
- **`fetchFinalizedGames`** (list path): now derives `value` explicitly from the last resolution/end-game box for consistency.
- **`devCommission`** added to the `GameFinalized` type (`src/lib/common/game.ts`) and populated from history in both construction sites, plus the dev-competitions fixture (`src/lib/dev/dev-competitions.ts`). Previously `getPrizePool()` read `devCommission` off the finalized object as `undefined → 0`, so the dev commission was never deducted from the finalized prize pool.

## Gates
- `npm run check` (svelte-check): **104 errors / 24 warnings — identical to `main` baseline.** Zero new errors in any touched file. The 104 errors are **pre-existing and unrelated** (e.g. `App.svelte`: GameDetails "has no default export", missing `Demo`; `tests/refund_after_cancel.test.ts` mock-chain party type mismatches). Not fixed here per scope.
- `npm run build` (vite + adapter-static): **✓ success.**

## Deviations / assumptions / needs live verification
- **Theme:** used the `rotationDeg` accumulator from the merged `skills` app rather than PR #172's `setTimeout`-based `turning` flag (rationale above). UX is equivalent.
- **Prize pool source (needs live-chain verification):** the fix uses the last resolution/end-game contract box's participation-token balance as the prize pool. This matches the contract's `box_value(SELF) - resolverStake` term. However, `end_game.es` computes the *true* prize pool as `box_value(SELF) - resolverStake + Σ(unbatched participation inputs spent in the same finalize tx)`. For finalized games where all participations were already batched into the contract box (the common case), the end-game box balance is exact. If a game is finalized while unbatched participation boxes are consumed in the finalize tx, the displayed pool could undercount by those late participations. Fully reconstructing that would require parsing the finalize spending transaction's participation inputs — flagged here rather than implemented, to match existing data-access patterns and avoid scope creep. **Recommend verifying against a real finalized game on-chain** (this clone had no live-chain access during implementation).
- No unrelated code touched; commits are split per task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
