### PR TITLE
fix: show prize pool & commissions for Finalized games

### DIFF
--- a/src/lib/ergo/fetch.ts
+++ b/src/lib/ergo/fetch.ts
@@ -1526,10 +1526,19 @@ export async function fetchGame(id: string): Promise<AnyGame | null> {
         // Prize pool is derived from the HISTORICAL record, not the live box. `currentBox`
         // (the box now holding the NFT) is a winner/resolver wallet box that no longer
         // carries the participation tokens, so `currentBox.value` / `lastBox.box.value`
-        // would report a near-zero prize pool. The last resolution/end-game contract box
-        // (spent by the finalize tx) still carries the participation-token balance, which
-        // is the final prize pool consumed by getPrizePool().
-        const finalPrizeValue = lastResolutionBox?.value ?? lastBox.value;
+        // would report a near-zero prize pool. The contract box that still carries the
+        // full pot (participation balance + stake) right before the finalize tx is the
+        // one with the LARGEST value across the historical record. Selecting the max is
+        // robust even when no Resolution box is present (e.g. games finalized straight
+        // from an end-game/timeout box) — the previous `lastResolutionBox?.value ??
+        // lastBox.value` fell back to a near-zero box in that case, yielding prize pool 0.
+        const maxHistValue = histBoxes.reduce(
+            (max, b) => (BigInt(b.value ?? 0n) > max ? BigInt(b.value ?? 0n) : max),
+            0n,
+        );
+        const finalPrizeValue =
+            lastResolutionBox?.value ??
+            (maxHistValue > 0n ? maxHistValue : lastBox.value);
 
         // build finalized object
         try {

--- a/src/routes/GameDetails.svelte
+++ b/src/routes/GameDetails.svelte
@@ -1910,8 +1910,9 @@
             platform = game.platform;
 
             // 2. Commission integration (unified logic)
-            // Only compute breakdown if the status exposes commissions
-            if (game.status === "Active" || game.status === "Resolution") {
+            // Compute breakdown for Active, Resolution, and Finalized games —
+            // all three statuses expose resolverCommission, devCommission, and perJudgeCommission.
+            if (game.status === "Active" || game.status === "Resolution" || game.status === "Finalized") {
                 const denominator = game.constants.COMMISSION_DENOMINATOR / 100;
                 resolverPct =
                     Number(game.resolverCommission ?? 0) / denominator;
@@ -1921,7 +1922,7 @@
                     denominator;
                 developersPct = Number(game.devCommission ?? 0) / denominator;
                 creatorSlashRatioPct =
-                    Number(game.creatorSlashRatio ?? 0) / denominator;
+                    Number((game as any).creatorSlashRatio ?? 0) / denominator;
                 totalPct = resolverPct + judgesTotalPct + developersPct;
                 winnerPct = Math.max(0, 100 - totalPct);
                 overAllocated =


### PR DESCRIPTION
## Problem

Finalized games show **Prize Pool = 0** and **Commissions = 0%** in the UI, despite the historical-record prize-pool reconstruction (#17) landing.

Two independent causes:

### 1. UI gated commission breakdown to non-finalized games
`GameDetails.svelte` only computed `resolverPct / judgesTotalPct / developersPct / totalPct` when `status === "Active" || "Resolution"`. Finalized games fell through with everything at 0, so "Commissions" rendered `0%`. `GameFinalized` already carries `resolverCommission`, `devCommission`, and `perJudgeCommission`, so the gate is widened to include `"Finalized"`. `creatorSlashRatio` (absent on `GameFinalized`) is read via `(game as any) ?? 0`.

### 2. Prize-pool value fell back to a near-zero box
In `fetch.ts`, `finalPrizeValue = lastResolutionBox?.value ?? lastBox.value`. When a game has **no Resolution box** in history (finalized straight from an end-game/timeout box), this fell back to `lastBox` — the post-finalization box holding the NFT in a winner/resolver wallet, whose value is ~0. `getPrizePool()` then computed a 0 pool (and the minimal-path commissions were 0 too).

Fix: select the historical contract box with the **largest value** as the pot-bearing box (it still carries participation balance + stake just before the finalize tx). Resolution box stays the preferred source; max-value is the robust fallback ahead of the near-zero `lastBox`.

## Verification
- `npx vitest run` → **67 passed** (12 files).
- `npm run check` → no new errors vs. `main` baseline (104 pre-existing, all in test mock-chain typings / a known `GameDetails` default-export svelte-check quirk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)