### PR TITLE
feat(mcp): resolve a game's service download URL on-chain

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -59,7 +59,7 @@ Reads need no signer. Writes pick one from the environment (default `unsigned`):
 SeedSigner derives with `@scure` (standard BIP-39/32), so it signs from the same
 address Nautilus would — it is reused from `reputation-system/node`, never re-rolled.
 
-## Tools (26)
+## Tools (28)
 
 **Info:** `get_gop_config`, `get_contracts_info` (every game/reputation contract's
 address + ErgoTree template hash + script hash, compiled from `contracts/*.es`),
@@ -71,6 +71,12 @@ address + ErgoTree template hash + script hash, compiled from `contracts/*.es`),
 
 **Participation reads:** `fetch_participations`, `fetch_participation_batches`,
 `fetch_solver_id_box`.
+
+**Service sources:** `fetch_service_download_url` (resolve a Celaut service hash —
+a game's `serviceId` — to a download URL via the source-application FILE_SOURCE
+registry), `get_game_service` (fetch a game by id and resolve its
+`{ serviceId, downloadUrl }` in one call, so an agent can obtain a competition's
+game service without being handed it).
 
 **Reputation / token / chain reads:** `fetch_opinions_about`,
 `fetch_token_details`, `token_creation_height`, `get_current_height`.

--- a/mcp/_entry.mjs
+++ b/mcp/_entry.mjs
@@ -120,3 +120,11 @@ export { explorer_uri, REPUTATION_PROOF_TOTAL_SUPPLY, isDevMode } from '../src/l
 
 // ── Byte/hex + parsing helpers — src/lib/ergo/utils.ts ────────────────────────
 export { hexToUtf8, hexToBytes, uint8ArrayToHex, parseCollByteToHex } from '../src/lib/ergo/utils.ts';
+
+// ── Service source resolution — src/lib/ergo/utils.ts ─────────────────────────
+// Resolves a Celaut service hash (a game's `serviceId`) to a download URL via the
+// source-application FILE_SOURCE registry. Exported here so esbuild does not
+// tree-shake it (it has no other caller in the bundled read graph); the
+// `source-application` import it pulls in is aliased to the Node adapter in
+// mcp/_stubs/sibling-apps.mjs by mcp/build.mjs.
+export { fetchServiceDownloadUrl } from '../src/lib/ergo/utils.ts';

--- a/mcp/_generated/lib.bundle.mjs
+++ b/mcp/_generated/lib.bundle.mjs
@@ -17,6 +17,98 @@ import {
 // _stubs/app-paths.mjs
 var base = "";
 
+// _stubs/sibling-apps.mjs
+import { searchBoxes, getTimestampFromBlockId } from "reputation-system/node";
+var FILE_SOURCE_TYPE_NFT_ID = "8299d98e15ebee7fa39ad716de7c8bb191790a1bf4b7c3f91af35a0e36187706";
+function hexToUtf8(hex2) {
+  if (!hex2 || typeof hex2 !== "string")
+    return null;
+  try {
+    return Buffer.from(hex2, "hex").toString("utf8");
+  } catch {
+    return null;
+  }
+}
+function deserializeSourceEntry(content) {
+  const empty = { hashFunctionId: "", contentFormat: "", contentHash: "", rawFormat: "", urlLink: "" };
+  if (!content || content.trim() === "")
+    return empty;
+  try {
+    const parsed = JSON.parse(content);
+    if (Array.isArray(parsed) && parsed.length > 0) {
+      const tuple = parsed[0];
+      if (Array.isArray(tuple) && tuple.length >= 5) {
+        return {
+          hashFunctionId: tuple[0] || "",
+          contentFormat: tuple[1] || "",
+          contentHash: tuple[2] || "",
+          rawFormat: tuple[3] || "",
+          urlLink: tuple[4] || "",
+          isChunked: tuple[5] === true
+        };
+      }
+      if (typeof tuple === "object" && tuple !== null && !Array.isArray(tuple)) {
+        return {
+          hashFunctionId: tuple.hashFunctionId || "",
+          contentFormat: tuple.contentFormat || tuple.contentFormatNftId || "",
+          contentHash: tuple.contentHash || "",
+          rawFormat: tuple.rawFormat || tuple.rawFormatNftId || "",
+          urlLink: tuple.urlLink || "",
+          isChunked: tuple.isChunked === true
+        };
+      }
+    }
+  } catch {
+  }
+  return { hashFunctionId: "", contentFormat: "", contentHash: "", rawFormat: "", urlLink: content, isChunked: false };
+}
+async function collectBoxes(generator) {
+  const boxes = [];
+  for await (const batch of generator)
+    boxes.push(...batch);
+  return boxes;
+}
+async function fetchFileSourcesByHash(fileHash, explorerUri) {
+  const generator = searchBoxes(
+    explorerUri,
+    void 0,
+    FILE_SOURCE_TYPE_NFT_ID,
+    fileHash,
+    void 0,
+    void 0,
+    void 0,
+    void 0,
+    void 0,
+    void 0
+  );
+  const boxes = await collectBoxes(generator);
+  const sources = [];
+  for (const box of boxes) {
+    if (!box.assets?.length)
+      continue;
+    if (box.additionalRegisters.R6?.renderedValue !== "false")
+      continue;
+    if (!box.additionalRegisters.R9?.renderedValue)
+      continue;
+    const sourceEntry = deserializeSourceEntry(
+      hexToUtf8(box.additionalRegisters.R9.renderedValue) ?? ""
+    );
+    sources.push({
+      id: box.boxId,
+      fileHash,
+      hashFunctionId: sourceEntry.hashFunctionId || "",
+      source: sourceEntry,
+      ownerTokenId: box.assets[0].tokenId,
+      reputationAmount: Number(box.assets[0].amount),
+      timestamp: await getTimestampFromBlockId(explorerUri, box.blockId),
+      isLocked: false,
+      transactionId: box.transactionId
+    });
+  }
+  sources.sort((a, b) => b.timestamp - a.timestamp);
+  return sources;
+}
+
 // ../node_modules/svelte/src/runtime/internal/utils.js
 function noop() {
 }
@@ -486,7 +578,7 @@ var CACHE_DURATION_MS = 1e4;
 var isDevMode = writable(false);
 
 // ../src/lib/ergo/utils.ts
-function hexToUtf8(hexString) {
+function hexToUtf82(hexString) {
   try {
     if (hexString.length % 2 !== 0) {
       return null;
@@ -607,6 +699,20 @@ function parseGameContent(rawJsonDetails, gameBoxId, nft) {
   }
   return content;
 }
+async function fetchServiceDownloadUrl(serviceId) {
+  const sources = await fetchFileSourcesByHash(serviceId, get_store_value(explorer_uri));
+  if (sources.length === 0) {
+    console.warn(`No sources found for serviceId ${serviceId}`);
+    return "N/A";
+  }
+  const primaryUrl = sources[0].source.urlLink;
+  if (!primaryUrl) {
+    console.warn(`No URL found in sources for serviceId ${serviceId}`);
+    return "N/A";
+  }
+  const serviceDownloadUrl = primaryUrl.startsWith("http") ? primaryUrl : `https://${primaryUrl}`;
+  return serviceDownloadUrl;
+}
 function getArrayFromValue(value) {
   if (Array.isArray(value))
     return value;
@@ -654,7 +760,7 @@ var false_default = "{\n  sigmaProp(false)\n}\n";
 
 // _stubs/reputation-system.mjs
 import {
-  searchBoxes,
+  searchBoxes as searchBoxes2,
   fetchAllProfiles,
   fetchTypeNfts,
   convertToRPBox
@@ -1883,7 +1989,7 @@ async function fetchJudges(force = false) {
 }
 async function fetchOpinionsAbout(objectPointer, typeNftId) {
   try {
-    const boxGenerator = searchBoxes(
+    const boxGenerator = searchBoxes2(
       get_store_value(explorer_uri),
       void 0,
       // tokenId (issuer)
@@ -2095,7 +2201,7 @@ async function parseGameActiveBox(box) {
     const devScript = parseCollByteToHex(r9Value[2]);
     if (!devScript)
       throw new Error("Could not parse devScript from R9.");
-    const gameDetailsJson = hexToUtf8(gameDetailsHex || "");
+    const gameDetailsJson = hexToUtf82(gameDetailsHex || "");
     const content = parseGameContent(gameDetailsJson, box.boxId, box.assets[0]);
     const gameActive = {
       platform: new ErgoPlatform(),
@@ -2220,7 +2326,7 @@ async function parseGameResolutionBox(box) {
     const resolverScript_Hex = parseCollByteToHex(r9Value[3]);
     if (!gameDetailsHex || !resolverScript_Hex || !devScript)
       throw new Error("Could not parse R9.");
-    const content = parseGameContent(hexToUtf8(gameDetailsHex), box.boxId, box.assets[0]);
+    const content = parseGameContent(hexToUtf82(gameDetailsHex), box.boxId, box.assets[0]);
     const resolverPK_Hex = resolverScript_Hex.slice(0, 6) == "0008cd" ? resolverScript_Hex.slice(6, resolverScript_Hex.length) : null;
     const gameResolution = {
       platform: new ErgoPlatform(),
@@ -2340,7 +2446,7 @@ async function parseGameCancellationBox(box) {
     }
     const gameDetailsHex = parseCollByteToHex(r9Value[0]);
     const participationTokenId = parseCollByteToHex(r9Value[1]);
-    const gameDetailsJson = hexToUtf8(gameDetailsHex || "");
+    const gameDetailsJson = hexToUtf82(gameDetailsHex || "");
     const content = parseGameContent(gameDetailsJson, box.boxId, box.assets[0]);
     if (isNaN(unlockHeight) || !revealedS_Hex || portionToClaim === void 0) {
       throw new Error("Invalid or missing registers R5, R6, or R7.");
@@ -3081,7 +3187,7 @@ async function fetchGame(id) {
       try {
         if (currentBox.additionalRegisters && currentBox.additionalRegisters.R9) {
           const hex2 = parseCollByteToHex(currentBox.additionalRegisters.R9?.renderedValue);
-          const json = hexToUtf8(hex2 || "");
+          const json = hexToUtf82(hex2 || "");
           content = parseGameContent(json, currentBox.boxId, currentBox.assets?.[0]);
         }
       } catch (e) {
@@ -3321,6 +3427,7 @@ export {
   fetchParticipationBatches,
   fetchParticipations,
   fetchResolutionGames,
+  fetchServiceDownloadUrl,
   fetchSolverIdBox,
   fetchTypeNfts2 as fetchTypeNfts,
   fetch_token_details,
@@ -3372,7 +3479,7 @@ export {
   getReputationProofScriptHash,
   getReputationProofTemplateHash,
   hexToBytes,
-  hexToUtf8,
+  hexToUtf82 as hexToUtf8,
   isDevMode,
   parseCollByteToHex,
   resolve_participation_commitment,

--- a/mcp/_stubs/sibling-apps.mjs
+++ b/mcp/_stubs/sibling-apps.mjs
@@ -1,11 +1,118 @@
-// Node-safe stub for the sibling Svelte packages `source-application` /
+// Node adapter for the sibling Svelte packages `source-application` /
 // `forum-application`, aliased in by mcp/build.mjs.
 //
-// `src/lib/ergo/utils.ts` imports `fetchFileSourcesByHash` from
-// `source-application` solely for `fetchServiceDownloadUrl()` — a helper that is
-// NOT reachable from the MCP's 26-tool read surface (no caller in the bundled
-// graph), so esbuild tree-shakes it away. The two packages only ship a Svelte
-// entry (not bare-Node loadable), so this inert stub lets the import resolve
-// before that dead code is dropped. If a future tool needs cross-registry source
-// lookups, replace this with the packages' own `/node` entry.
-export const fetchFileSourcesByHash = async () => [];
+// The browser app imports these packages' Svelte entry (`dist/index.js`), which
+// re-exports Svelte components and is NOT loadable in bare Node. The MCP read
+// graph needs exactly ONE symbol from them: `source-application`'s
+// `fetchFileSourcesByHash`, used by `src/lib/ergo/utils.ts:fetchServiceDownloadUrl`
+// to resolve a Celaut service hash (a game's `serviceId`) to a download URL.
+//
+// Rather than pull the un-loadable Svelte bundle, this file ports that ONE read
+// against the SAME on-chain primitives the rest of the headless surface uses:
+// `searchBoxes` + `getTimestampFromBlockId` from `reputation-system/node` (kept
+// external / resolved from node_modules by mcp/build.mjs, so no drift with the
+// installed package the reads + writes already use). The logic mirrors
+// `source-application/src/lib/ergo/sourceFetch.ts:fetchFileSourcesByHash` and
+// `sourceObject.ts:deserializeSourceEntry`. The upstream `DOMPurify.sanitize`
+// step is display-only (HTML safety for the web UI) and is intentionally omitted
+// here — the MCP consumes the parsed `urlLink`, it does not render R9 as HTML.
+//
+// `forum-application` has no caller in the bundled read graph (only browser
+// routes import it), so it stays inert.
+import { searchBoxes, getTimestampFromBlockId } from 'reputation-system/node';
+
+// source-application/src/lib/ergo/envs.ts — FILE_SOURCE box Type NFT id.
+const FILE_SOURCE_TYPE_NFT_ID =
+  '8299d98e15ebee7fa39ad716de7c8bb191790a1bf4b7c3f91af35a0e36187706';
+
+function hexToUtf8(hex) {
+  if (!hex || typeof hex !== 'string') return null;
+  try {
+    return Buffer.from(hex, 'hex').toString('utf8');
+  } catch {
+    return null;
+  }
+}
+
+// Port of source-application/src/lib/ergo/sourceObject.ts:deserializeSourceEntry.
+// Parses a FILE_SOURCE box's R9 content into a single source entry, tolerating
+// the tuple-array format, the legacy JSON-object format, and a bare URL string.
+function deserializeSourceEntry(content) {
+  const empty = { hashFunctionId: '', contentFormat: '', contentHash: '', rawFormat: '', urlLink: '' };
+  if (!content || content.trim() === '') return empty;
+  try {
+    const parsed = JSON.parse(content);
+    if (Array.isArray(parsed) && parsed.length > 0) {
+      const tuple = parsed[0];
+      if (Array.isArray(tuple) && tuple.length >= 5) {
+        return {
+          hashFunctionId: tuple[0] || '',
+          contentFormat: tuple[1] || '',
+          contentHash: tuple[2] || '',
+          rawFormat: tuple[3] || '',
+          urlLink: tuple[4] || '',
+          isChunked: tuple[5] === true
+        };
+      }
+      if (typeof tuple === 'object' && tuple !== null && !Array.isArray(tuple)) {
+        return {
+          hashFunctionId: tuple.hashFunctionId || '',
+          contentFormat: tuple.contentFormat || tuple.contentFormatNftId || '',
+          contentHash: tuple.contentHash || '',
+          rawFormat: tuple.rawFormat || tuple.rawFormatNftId || '',
+          urlLink: tuple.urlLink || '',
+          isChunked: tuple.isChunked === true
+        };
+      }
+    }
+  } catch {
+    // Not JSON — fall through to the legacy plain-URL form.
+  }
+  return { hashFunctionId: '', contentFormat: '', contentHash: '', rawFormat: '', urlLink: content, isChunked: false };
+}
+
+async function collectBoxes(generator) {
+  const boxes = [];
+  for await (const batch of generator) boxes.push(...batch);
+  return boxes;
+}
+
+/**
+ * Fetch all FILE_SOURCE boxes for a file hash, newest first.
+ * Port of source-application's read; each entry's `source.urlLink` is a download
+ * URL published for the hash. `fetchServiceDownloadUrl` takes the first one.
+ */
+export async function fetchFileSourcesByHash(fileHash, explorerUri) {
+  const generator = searchBoxes(
+    explorerUri, undefined, FILE_SOURCE_TYPE_NFT_ID, fileHash,
+    undefined, undefined, undefined, undefined, undefined, undefined
+  );
+  const boxes = await collectBoxes(generator);
+
+  const sources = [];
+  for (const box of boxes) {
+    if (!box.assets?.length) continue;
+    // R6 === "false" marks an unlocked/live FILE_SOURCE box (the app's invariant).
+    if (box.additionalRegisters.R6?.renderedValue !== 'false') continue;
+    if (!box.additionalRegisters.R9?.renderedValue) continue;
+
+    const sourceEntry = deserializeSourceEntry(
+      hexToUtf8(box.additionalRegisters.R9.renderedValue) ?? ''
+    );
+
+    sources.push({
+      id: box.boxId,
+      fileHash,
+      hashFunctionId: sourceEntry.hashFunctionId || '',
+      source: sourceEntry,
+      ownerTokenId: box.assets[0].tokenId,
+      reputationAmount: Number(box.assets[0].amount),
+      timestamp: await getTimestampFromBlockId(explorerUri, box.blockId),
+      isLocked: false,
+      transactionId: box.transactionId
+    });
+  }
+
+  sources.sort((a, b) => b.timestamp - a.timestamp);
+  return sources;
+}

--- a/mcp/core.mjs
+++ b/mcp/core.mjs
@@ -137,6 +137,22 @@ export async function fetchParticipationBatches(gameId) {
 
 export const fetchSolverIdBox = async (solverId) => jsonSafe(await lib.fetchSolverIdBox(solverId));
 
+// ── Reads: service sources (src/lib/ergo/utils.ts:fetchServiceDownloadUrl) ─────
+// Resolve a Celaut service hash to a download URL via the source-application
+// FILE_SOURCE registry. Returns "N/A" when no source box publishes the hash.
+export const fetchServiceDownloadUrl = async (serviceId) => lib.fetchServiceDownloadUrl(serviceId);
+
+// Convenience: fetch a game by id and resolve its competition game-service in one
+// call. `serviceId` comes from the game box's R9 game-details JSON.
+export async function getGameService(gameId) {
+  const game = await lib.fetchGame(gameId);
+  if (!game) return { gameId, serviceId: '', downloadUrl: 'N/A', title: null };
+  const serviceId = game.content?.serviceId || '';
+  const title = game.content?.title ?? null;
+  if (!serviceId) return { gameId, serviceId: '', downloadUrl: 'N/A', title };
+  return { gameId, serviceId, downloadUrl: await lib.fetchServiceDownloadUrl(serviceId), title };
+}
+
 // ── Reads: reputation / tokens / chain ──────────────────────────────────────
 export const fetchOpinionsAbout = async (objectPointer, typeNftId) =>
   jsonSafe(await lib.fetchOpinionsAbout(objectPointer, typeNftId));

--- a/mcp/tools.mjs
+++ b/mcp/tools.mjs
@@ -90,6 +90,18 @@ export const TOOLS = [
     inputSchema: { type: 'object', properties: { solverId: { type: 'string' } }, required: ['solverId'], additionalProperties: false }
   },
 
+  // ── Reads: service sources ──────────────────────────────────────────────────
+  {
+    name: 'fetch_service_download_url',
+    description: 'Resolve a Celaut service hash (a game\'s serviceId) to a download URL from its newest FILE_SOURCE box in the source-application registry. Returns "N/A" if no source publishes the hash.',
+    inputSchema: { type: 'object', properties: { serviceId: { type: 'string' } }, required: ['serviceId'], additionalProperties: false }
+  },
+  {
+    name: 'get_game_service',
+    description: 'Fetch a game by NFT id and resolve its competition game-service in one call: returns { serviceId, downloadUrl, title }. Convenience over fetch_game + fetch_service_download_url — the agent needs no game service passed to it.',
+    inputSchema: { type: 'object', properties: { gameId: { type: 'string' } }, required: ['gameId'], additionalProperties: false }
+  },
+
   // ── Reads: reputation / tokens / chain ──────────────────────────────────────
   {
     name: 'fetch_opinions_about',
@@ -225,6 +237,10 @@ export const HANDLERS = {
   fetch_participations: async ({ gameId, participationTokenId }) => core.fetchParticipations(gameId, participationTokenId),
   fetch_participation_batches: async ({ gameId }) => core.fetchParticipationBatches(gameId),
   fetch_solver_id_box: async ({ solverId }) => core.fetchSolverIdBox(solverId),
+
+  // reads: service sources
+  fetch_service_download_url: async ({ serviceId }) => ({ serviceId, downloadUrl: await core.fetchServiceDownloadUrl(serviceId) }),
+  get_game_service: async ({ gameId }) => core.getGameService(gameId),
 
   // reads: reputation / tokens / chain
   fetch_opinions_about: async ({ objectPointer, typeNftId }) => core.fetchOpinionsAbout(objectPointer, typeNftId),


### PR DESCRIPTION
## Why

An agent using the Game of Prompts MCP could read a game but had **no way to obtain that competition's game service** — it had to be handed the artifact out of band. This adds the missing link: game → `serviceId` → download URL, resolved on-chain.

## What

Two read tools (26 → 28):

- **`fetch_service_download_url(serviceId)`** — resolve a Celaut service hash (a game's `serviceId`) to a download URL via the `source-application` FILE_SOURCE registry. Returns `"N/A"` when no source publishes the hash.
- **`get_game_service(gameId)`** — fetch a game and resolve its `{ serviceId, downloadUrl, title }` in one call.

## How

`src/lib/ergo/utils.ts:fetchServiceDownloadUrl` already existed, but was unreachable from the MCP: the read bundle aliased `source-application` to an inert stub (`fetchFileSourcesByHash → []`) because the package only ships a Svelte entry, and the helper had no caller so esbuild tree-shook it away.

- **`mcp/_stubs/sibling-apps.mjs`** — replace the inert stub with a real Node adapter. Ports `fetchFileSourcesByHash` over `reputation-system/node`'s `searchBoxes` + `getTimestampFromBlockId` (already external at MCP runtime, so no dependency drift). Mirrors upstream `source-application`'s `sourceFetch.ts` + `sourceObject.ts:deserializeSourceEntry`; the display-only `DOMPurify.sanitize` step is intentionally dropped (the MCP consumes the parsed `urlLink`, it does not render R9 as HTML).
- **`mcp/_entry.mjs`** — re-export `fetchServiceDownloadUrl` so esbuild keeps it.
- **`mcp/core.mjs`** — `fetchServiceDownloadUrl` + `getGameService` wrappers.
- **`mcp/tools.mjs`** — the two tools + handlers (shared by the stdio server and the sealed `.service` HTTP twin).
- Rebuilt `_generated/lib.bundle.mjs`; README 26 → 28.

No `src/` (web app) or theme files touched — additive to the MCP surface only. The web app keeps using the real `source-application` package unchanged.

## Verification

Against Ergo mainnet, over the stdio JSON-RPC server (`tools/list` reports 28 tools):

```
tools/call fetch_service_download_url
  { serviceId: "4935947765d09492bbac0c07baa5af4ab746278ca839e61186cd40f46f3ecb82" }
→ { downloadUrl: "https://raw.githubusercontent.com/celaut-project/paradigm/refs/heads/master/README.md" }
```

Multi-source hashes return the newest source (sorted by block timestamp, desc); a hash with no FILE_SOURCE box returns `"N/A"`.

> Note: `get_game_service` depends on `fetch_game` parsing the game box. On the clone I tested, the deployed game/mintIdt contracts have different ErgoTree template hashes than this repo's `contracts/*.es` compile to (`fetch_active_games` returns 0 with `parseGameActiveBox: invalid constants`), so I couldn't extract a live competition's `serviceId` end-to-end — that's a separate contract-version drift, unrelated to this PR. `fetch_service_download_url` is contract-version-independent and is fully verified above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)