### PR TITLE
fix(mcp): expose FINALIZED games — fetch_all_games missed the whole state

### DIFF
--- a/mcp/core.mjs
+++ b/mcp/core.mjs
@@ -95,15 +95,18 @@ export const fetchActiveGames = async () => jsonSafe(await lib.fetchActiveGames(
 export const fetchResolutionGames = async () => jsonSafe(await lib.fetchResolutionGames());
 export const fetchCancellationGames = async () => jsonSafe(await lib.fetchCancellationGames());
 
-/** All games across active + resolution + cancellation (deduped by gameId). */
+export const fetchFinalizedGames = async () => jsonSafe(await lib.fetchFinalizedGames());
+
+/** All games across active + resolution + cancellation + finalized (deduped by gameId). */
 export async function fetchAllGames() {
-  const [active, resolution, cancellation] = await Promise.all([
+  const [active, resolution, cancellation, finalized] = await Promise.all([
     lib.fetchActiveGames(),
     lib.fetchResolutionGames(),
-    lib.fetchCancellationGames()
+    lib.fetchCancellationGames(),
+    lib.fetchFinalizedGames()
   ]);
   const map = new Map();
-  for (const g of [...active.values(), ...resolution.values(), ...cancellation.values()]) {
+  for (const g of [...active.values(), ...resolution.values(), ...cancellation.values(), ...finalized.values()]) {
     map.set(g.gameId, g);
   }
   return jsonSafe([...map.values()]);

--- a/mcp/tools.mjs
+++ b/mcp/tools.mjs
@@ -48,8 +48,13 @@ export const TOOLS = [
     inputSchema: { type: 'object', properties: {}, additionalProperties: false }
   },
   {
+    name: 'fetch_finalized_games',
+    description: 'All games that already completed their lifecycle (FINALIZED): the game NFT no longer sits in a game contract box. Reconstructed from the spent-box history. Slower than the other game reads.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false }
+  },
+  {
     name: 'fetch_all_games',
-    description: 'All games across the active + resolution + cancellation states.',
+    description: 'All games across the active + resolution + cancellation + finalized states.',
     inputSchema: { type: 'object', properties: {}, additionalProperties: false }
   },
   {
@@ -227,6 +232,7 @@ export const HANDLERS = {
   fetch_active_games: async () => core.fetchActiveGames(),
   fetch_resolution_games: async () => core.fetchResolutionGames(),
   fetch_cancellation_games: async () => core.fetchCancellationGames(),
+  fetch_finalized_games: async () => core.fetchFinalizedGames(),
   fetch_all_games: async () => core.fetchAllGames(),
   fetch_game: async ({ gameId }) => core.fetchGame(gameId),
   load_game_by_id: async ({ gameId }) => core.fetchGame(gameId),


### PR DESCRIPTION
## Problem

`fetchAllGames` in `mcp/core.mjs` merged only **active + resolution + cancellation**. A game whose NFT has left the game contracts (lifecycle complete) was invisible to every MCP consumer — no tool exposed that state at all.

`fetchFinalizedGames` already exists in `src/lib/ergo/fetch.ts:702`, is re-exported by `mcp/_entry.mjs:79` and is compiled into `_generated/lib.bundle.mjs`. It was simply never called from the MCP surface, even though the web app uses it.

On mainnet today this made the entire read surface look empty. `fetch_all_games` returned `[]`, while the only real competition — **Snake Challenge #1** (`889fd2c746822f4c052a460403a90d4cf67129b2c68ed21840568cb940d4dab5`) — had already completed its lifecycle: created at height 1786042, resolution at 1798619, NFT returned to the creator's P2PK at 1799644.

For the record, the 8 unspent boxes the explorer still returns for the `game_active` template hash (`901b0fe9…`) are leftovers from an earlier contract version — same template hash, different constants — and `parseGameActiveBox` rejects them correctly. The contracts in `main` are in sync with what is deployed: the ErgoTree of the Snake Challenge #1 creation box is byte-identical to the locally compiled one (3524 chars, `19df0d4c04040e20426d25e2…`).

## Changes

- `mcp/core.mjs` — export `fetchFinalizedGames`; include it in `fetchAllGames`'s `Promise.all` and dedup.
- `mcp/tools.mjs` — add the `fetch_finalized_games` tool + handler; fix the now-inaccurate `fetch_all_games` description.

No changes to `src/`, `contracts/` or the generated bundle, so **no `npm run build:mcp` is needed**.

## Verification

Run over stdio against `api.ergoplatform.com` through the actual MCP server (not by calling the library directly):

```
fetch_finalized_games →  n = 1
  889fd2c746822f4c052a460403a90d4cf67129b2c68ed21840568cb940d4dab5 | Snake Challenge #1 | Finalized

fetch_all_games      →  n = 1   (was [] before this patch)
  889fd2c746822f4c052a460403a90d4cf67129b2c68ed21840568cb940d4dab5 | Snake Challenge #1 | Finalized
```

`fetch_active_games`, `fetch_resolution_games` and `fetch_cancellation_games` still return `[]`, which is correct — there is no live game on chain right now.

## Known cost, left for a follow-up

`fetchFinalizedGames` walks all four template hashes over `/boxes/search` (spent boxes included) and then re-runs the three unspent reads internally to filter (`fetch.ts:763-765`). So those three reads now execute twice per call and `fetch_all_games` went from seconds to ~2 min. Avoiding it means changing a `src/` signature shared with the web app, which is deliberately out of scope here. The cost is flagged in the tool description.

Two other follow-ups noted while working on this, not addressed:
- The parser rejection logs (`invalid constants`, `fetch_conditions: …`) are legitimate but noisy on a stdio server's stderr.
- Game reads embed the full `box` object (3524-char `ergoTree` + serialized registers) per game, which is a large payload for an agent that rarely needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
